### PR TITLE
Lines with zero length cause  trimming to be incorrect

### DIFF
--- a/tiles.py
+++ b/tiles.py
@@ -25,7 +25,7 @@ def __trim(t):
     lns = [ln.rstrip() for ln in t.split("\n")]
     lns = [ln for ln in dropwhile(lambda ln: len(ln) == 0, lns)]
     lns = [ln for ln in dropwhile(lambda ln: len(ln) == 0, reversed(lns))]
-    left = min([len(ln) - len(ln.lstrip()) for ln in lns])
+    left = min([len(ln) - len(ln.lstrip()) for ln in filter(bool, lns)])
     return [ln[left:] for ln in reversed(lns)]
 
 def __append(t1, t2):


### PR DESCRIPTION
Here is an example:
```python
from tiles import tile

test = """
          XX        
          XX
          """

colors = tile("""
         White
         Black
         Ultramarine
         Red
         Green
         Blue

         @{test}
         """)

shapes = tile("""
              Triangle
              Circle

              @{test}
              """)

output = tile("""
              Colors: @{colors}     Shapes: @{shapes}
              That's all, folks!
              """)

print output
```

The output is:
```

              Colors:          White           Shapes:               Triangle
                               Black                                 Circle
                               Ultramarine             
                               Red                                   XX
                               Green                                 XX
                               Blue
                      
                               XX
                               XX
              That's all, folks!
              
```

After the adjustment:

```

              Colors: White           Shapes: Triangle
                      Black                   Circle
                      Ultramarine             
                      Red                     XX
                      Green                   XX
                      Blue
                      
                      XX
                      XX
              That's all, folks!
              
```

It seems also that the outermost `tile` is not left trimmed, but it probably should be (this can be seen in the above outputs).